### PR TITLE
Create tag-on-pr-close.yml

### DIFF
--- a/.github/workflows/tag-on-pr-close.yml
+++ b/.github/workflows/tag-on-pr-close.yml
@@ -1,0 +1,26 @@
+name: Tag on PR Close
+
+on:
+  pull_request:
+    types:
+      -closed
+    branches:
+      - main
+
+jobs:
+  tag:
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Create and push tag
+        env:
+          TAG_NAME: $(date +'%Y%m%d%H%M%S')
+        run: |
+          git config --global user.name "github-actions[bot]"
+          git config --global user.email "github-actions[bot]@users.noreply.github.com"
+          git tag $TAG_NAME
+          git push origin $TAG_NAME


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow to automatically tag the repository when a pull request is closed and merged into the main branch.